### PR TITLE
Refactor stats snapshots and metric rows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,7 @@ fn run_app(
 
     drop(stop_txs);
     for worker in workers {
-        worker.join().expect("worker thread panicked");
+        worker.join().map_err(|_| "worker thread panicked")?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,41 +57,22 @@ impl StatsSnapshot {
 }
 
 pub struct SharedStat {
-    pub region: &'static str,
     snapshot: Mutex<StatsSnapshot>,
 }
 
 impl SharedStat {
     fn new(region: &'static str) -> Self {
         Self {
-            region,
             snapshot: Mutex::new(StatsSnapshot::empty(region)),
         }
     }
 
     fn publish(&self, stats: &mut PingStats) {
-        let snapshot = StatsSnapshot {
-            region: stats.region,
-            last: stats.last(),
-            min: stats.min(),
-            avg: stats.avg(),
-            max: stats.max(),
-            stddev: stats.stddev(),
-            p95: stats.p95(),
-            p99: stats.p99(),
-            samples: stats.total_samples(),
-        };
-
-        if let Ok(mut guard) = self.snapshot.lock() {
-            *guard = snapshot;
-        }
+        *self.snapshot.lock().expect("shared stat mutex poisoned") = stats.snapshot();
     }
 
     fn read(&self) -> StatsSnapshot {
-        match self.snapshot.lock() {
-            Ok(guard) => *guard,
-            Err(_) => StatsSnapshot::empty(self.region),
-        }
+        *self.snapshot.lock().expect("shared stat mutex poisoned")
     }
 }
 
@@ -219,7 +200,7 @@ fn run_app(
 
     drop(stop_txs);
     for worker in workers {
-        let _ = worker.join();
+        worker.join().expect("worker thread panicked");
     }
 
     Ok(())
@@ -234,10 +215,10 @@ fn spawn_worker(
     notify_tx: SyncSender<()>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
-        let client = match Client::builder().redirect(redirect::Policy::none()).build() {
-            Ok(client) => client,
-            Err(_) => return,
-        };
+        let client = Client::builder()
+            .redirect(redirect::Policy::none())
+            .build()
+            .expect("http client build failed");
 
         let mut local_stats = PingStats::new(region.name);
         while !stop_requested(&stop_rx) {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 
+use crate::StatsSnapshot;
+
 const CAPACITY: usize = 128;
 
 #[derive(Clone, Copy, Default)]
@@ -86,10 +88,6 @@ impl PingStats {
         self.last_value
     }
 
-    pub fn total_samples(&self) -> u64 {
-        self.total_samples
-    }
-
     pub fn avg(&self) -> Option<f64> {
         if self.welford_count == 0 {
             return None;
@@ -145,6 +143,20 @@ impl PingStats {
         Some(self.percentile_cache.p99)
     }
 
+    pub fn snapshot(&mut self) -> StatsSnapshot {
+        StatsSnapshot {
+            region: self.region,
+            last: self.last(),
+            min: self.min(),
+            avg: self.avg(),
+            max: self.max(),
+            stddev: self.stddev(),
+            p95: self.p95(),
+            p99: self.p99(),
+            samples: self.total_samples,
+        }
+    }
+
     fn recompute_min_max(&mut self) {
         let mut min_val = f64::INFINITY;
         let mut max_val = -f64::INFINITY;
@@ -171,9 +183,9 @@ impl PingStats {
 
         let mut scratch = [0.0_f64; CAPACITY];
         let start = (self.head + CAPACITY - self.len) & (CAPACITY - 1);
-        for i in 0..self.len {
+        for (i, value) in scratch.iter_mut().take(self.len).enumerate() {
             let idx = (start + i) & (CAPACITY - 1);
-            scratch[i] = self.buffer[idx];
+            *value = self.buffer[idx];
         }
 
         let values = &mut scratch[..self.len];

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -145,53 +145,8 @@ fn draw_warmup(frame: &mut Frame, elapsed: Duration, remaining: Duration, total_
 }
 
 fn row_for_snapshot(snapshot: &StatsSnapshot, visible_cols: usize) -> Row<'static> {
-    match visible_cols {
-        2 => Row::new([
-            Cell::from(snapshot.region).style(TEXT_STYLE),
-            Cell::from(format_latency(snapshot.last))
-                .style(style_for_last(snapshot.last, snapshot.avg)),
-        ]),
-        3 => Row::new([
-            Cell::from(snapshot.region).style(TEXT_STYLE),
-            Cell::from(format_latency(snapshot.last))
-                .style(style_for_last(snapshot.last, snapshot.avg)),
-            Cell::from(format_latency(snapshot.min)).style(YELLOW_STYLE),
-        ]),
-        4 => Row::new([
-            Cell::from(snapshot.region).style(TEXT_STYLE),
-            Cell::from(format_latency(snapshot.last))
-                .style(style_for_last(snapshot.last, snapshot.avg)),
-            Cell::from(format_latency(snapshot.min)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.avg)).style(YELLOW_STYLE),
-        ]),
-        5 => Row::new([
-            Cell::from(snapshot.region).style(TEXT_STYLE),
-            Cell::from(format_latency(snapshot.last))
-                .style(style_for_last(snapshot.last, snapshot.avg)),
-            Cell::from(format_latency(snapshot.min)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.avg)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.max)).style(YELLOW_STYLE),
-        ]),
-        6 => Row::new([
-            Cell::from(snapshot.region).style(TEXT_STYLE),
-            Cell::from(format_latency(snapshot.last))
-                .style(style_for_last(snapshot.last, snapshot.avg)),
-            Cell::from(format_latency(snapshot.min)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.avg)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.max)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.stddev)).style(YELLOW_STYLE),
-        ]),
-        7 => Row::new([
-            Cell::from(snapshot.region).style(TEXT_STYLE),
-            Cell::from(format_latency(snapshot.last))
-                .style(style_for_last(snapshot.last, snapshot.avg)),
-            Cell::from(format_latency(snapshot.min)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.avg)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.max)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.stddev)).style(YELLOW_STYLE),
-            Cell::from(format_latency(snapshot.p95)).style(YELLOW_STYLE),
-        ]),
-        _ => Row::new([
+    Row::new(
+        [
             Cell::from(snapshot.region).style(TEXT_STYLE),
             Cell::from(format_latency(snapshot.last))
                 .style(style_for_last(snapshot.last, snapshot.avg)),
@@ -201,8 +156,10 @@ fn row_for_snapshot(snapshot: &StatsSnapshot, visible_cols: usize) -> Row<'stati
             Cell::from(format_latency(snapshot.stddev)).style(YELLOW_STYLE),
             Cell::from(format_latency(snapshot.p95)).style(YELLOW_STYLE),
             Cell::from(format_latency(snapshot.p99)).style(YELLOW_STYLE),
-        ]),
-    }
+        ]
+        .into_iter()
+        .take(visible_cols),
+    )
 }
 
 fn compare_snapshot(lhs: &StatsSnapshot, rhs: &StatsSnapshot) -> Ordering {


### PR DESCRIPTION
## Summary
- centralize stats snapshot construction in PingStats
- fail loud on poisoned stat mutexes and worker/client failures while preserving terminal cleanup
- unify metric row rendering into one visible-column path

## Proof
- cargo fmt --check
- cargo test
- cargo clippy -- -D warnings
- autoreview clean: no accepted/actionable findings reported

Not originally a bug fix; autoreview found and fixed a terminal-cleanup regression in the first refactor pass.